### PR TITLE
[RFR-ne pas merge] add Route choice type for page form

### DIFF
--- a/Form/RouteChoiceType.php
+++ b/Form/RouteChoiceType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Opera\AdminBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RouteChoiceType extends AbstractType
+{
+    private $routes;
+
+    public function __construct(RouterInterface $router)
+    {
+        foreach ($router->getRouteCollection()->all() as $routeName => $route) {
+            if ($route->getDefault("_controller")) {
+                $controllerName = $this->getControllerName($route->getDefault("_controller"));
+                if ($controllerName) {
+                    $this->routes[$controllerName][$routeName] = $routeName;
+                } else {
+                    $this->routes["Other"][$routeName] = $routeName;
+                }
+            }
+
+        }
+    }
+
+    /**
+     * ex:
+     *  input -> "Opera\AdminBundle\Controller\AdminPagesController::layout"
+     *  output -> "AdminPagesController"
+     */
+    private function getControllerName(string $controllerRoutePath)
+    {
+        preg_match('/.*\\\\(.*)::.*/', $controllerRoutePath, $matches);
+
+        if (isset($matches[1])) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'choices' => $this->routes,
+        ]);
+    }
+
+    public function getParent()
+    {
+        return \Symfony\Component\Form\Extension\Core\Type\ChoiceType::class;
+    }
+}

--- a/Form/RouteChoiceType.php
+++ b/Form/RouteChoiceType.php
@@ -34,11 +34,11 @@ class RouteChoiceType extends AbstractType
     {
         preg_match('/.*\\\\(.*)::.*/', $controllerRoutePath, $matches);
 
-        if (isset($matches[1])) {
-            return $matches[1];
+        if (!isset($matches[1])) {
+            return null;
         }
 
-        return null;
+        return $matches[1];
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/Form/RouteChoiceType.php
+++ b/Form/RouteChoiceType.php
@@ -21,7 +21,6 @@ class RouteChoiceType extends AbstractType
                     $this->routes["Other"][$routeName] = $routeName;
                 }
             }
-
         }
     }
 

--- a/Resources/config/easy_admin.yaml
+++ b/Resources/config/easy_admin.yaml
@@ -14,7 +14,7 @@ easy_admin:
                     - title
                     - { property: 'slug', type_options: { required: false } }
                     - { property: 'status', type: 'choice', type_options: { choices: { 'published': 'published', 'draft': 'draft' } } }
-                    - route
+                    - { property: 'route', type: 'Opera\AdminBundle\Form\RouteChoiceType' }
                     - { property: 'configuration', type: 'Opera\AdminBundle\Form\JsonType' }
                     - { property: 'requirements', type: 'Opera\AdminBundle\Form\JsonType' }
                     - { property: 'is_regexp', help: 'If is not a route and want dynamics params' }

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -23,3 +23,8 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
+    
+    Opera\AdminBundle\Form\RouteChoiceType:
+        arguments: [ '@router' ]
+        tags: 
+            - { name: 'form.type', alias: 'operaadmin_routechoice' }


### PR DESCRIPTION
Petite update 11 mois plus tard après tests:

J'ai un probleme car pour le RouteChoiceType.php je me sert de la liste des routes (la même qu'on recupere quand on fait `./bin/console route:debug` Or cette liste a les routes custom grâce au CmsRoutesLoader.php (core-bundle opera) qui lui même load les liste qui sont assigné a une page.
Probleme ex:

initial: J'ai une page article qui utilise la route `page_article`, je retrouve donc cette route dans mon RouteChoiceType et quand je fais route:debug.
step1: je retire cette route de la page.
step2: si je fait `route:debug`: la route page_article n'est plus là car n'est plus lié a une page (voir CmsRoutesLoader du core bundle) et elle n'existe plus dans mon  RouteChoiceType donc je ne peut plus la re-selectionner
step3: je peut pas la reselectionner, la route a disparu :(